### PR TITLE
[WIP] wcnss_service: Drop vendor build guard

### DIFF
--- a/wcnss-service/Android.mk
+++ b/wcnss-service/Android.mk
@@ -1,9 +1,7 @@
 ifneq (,$(filter arm aarch64 arm64, $(TARGET_ARCH)))
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
-ifeq ($(PRODUCT_VENDOR_MOVE_ENABLED),true)
 LOCAL_VENDOR_MODULE := true
-endif
 LOCAL_MODULE := wcnss_service
 LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/common/inc/
 LOCAL_SRC_FILES := wcnss_service.c


### PR DESCRIPTION
The `PRODUCT_VENDOR_MOVE_ENABLED` buildvar is never set in the device trees, causing this module to be installed to /system.

Drop the build guard to always install to /vendor.