### PR TITLE
[DONOTMERGE] Use PROPRIETARY_MODULE for backward compatibility

### DIFF
--- a/wcnss-service/Android.mk
+++ b/wcnss-service/Android.mk
@@ -1,7 +1,7 @@
 ifneq (,$(filter arm aarch64 arm64, $(TARGET_ARCH)))
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE := true
+LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE := wcnss_service
 LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/common/inc/
 LOCAL_SRC_FILES := wcnss_service.c

--- a/wcnss-service/Android.mk
+++ b/wcnss-service/Android.mk
@@ -1,9 +1,7 @@
 ifneq (,$(filter arm aarch64 arm64, $(TARGET_ARCH)))
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
-ifeq ($(PRODUCT_VENDOR_MOVE_ENABLED),true)
 LOCAL_VENDOR_MODULE := true
-endif
 LOCAL_MODULE := wcnss_service
 LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/common/inc/
 LOCAL_SRC_FILES := wcnss_service.c


### PR DESCRIPTION
Dependent on #1 

Nougat cannot recognize `LOCAL_VENDOR_MODULE`.
@alviteri does this make sense? Afaics only tama/nile use this, and they've never used Nougat.